### PR TITLE
DL-8030 bootstrap-play and play 2.8.16 upgrades

### DIFF
--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -4,15 +4,15 @@ import sbt._
 object AppDependencies {
 
   val compile = Seq(
-    "uk.gov.hmrc" %% "bootstrap-frontend-play-28" % "5.18.0",
-    "uk.gov.hmrc" %% "play-frontend-hmrc"         % "1.31.0-play-28",
-    "uk.gov.hmrc" %% "play-language"              % "5.1.0-play-28"
+    "uk.gov.hmrc" %% "bootstrap-frontend-play-28" % "5.25.0",
+    "uk.gov.hmrc" %% "play-frontend-hmrc"         % "3.21.0-play-28",
+    "uk.gov.hmrc" %% "play-language"              % "5.3.0-play-28"
   )
 
   val test = Seq(
-    "uk.gov.hmrc"            %% "bootstrap-test-play-28" % "5.18.0",
+    "uk.gov.hmrc"            %% "bootstrap-test-play-28" % "5.25.0",
     "org.scalamock"          %% "scalamock"              % "5.2.0",
-    "org.jsoup"              % "jsoup"                   % "1.14.3",
+    "org.jsoup"              % "jsoup"                   % "1.15.1",
     "com.typesafe.play"      %% "play-test"              % PlayVersion.current,
     "org.pegdown"            % "pegdown"                 % "1.6.0"
   ).map(_ % "test, it")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,11 +5,11 @@ addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.6.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.1.0")
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.8")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.16")
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.9.3")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.0")
 
 addSbtPlugin("org.irundaia.sbt" % "sbt-sassify" % "1.5.1")
 


### PR DESCRIPTION
Upgraded to use bootstrap-play 5.25.0  and play 2.8.16 . This is to protect against a security vulnerability that has been found in Play, and comes of the back of this [techspace blog](https://confluence.tools.tax.service.gov.uk/pages/viewpage.action?pageId=447906456).