### PR TITLE
DL-9499 update play frontend hmrc to latest

### DIFF
--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -5,8 +5,7 @@ object AppDependencies {
 
   val compile = Seq(
     "uk.gov.hmrc" %% "bootstrap-frontend-play-28" % "5.25.0",
-    "uk.gov.hmrc" %% "play-frontend-hmrc"         % "4.1.0-play-28",
-    "uk.gov.hmrc" %% "play-language"              % "6.1.0-play-28"
+    "uk.gov.hmrc" %% "play-frontend-hmrc"         % "6.2.0-play-28"
   )
 
   val test = Seq(


### PR DESCRIPTION
Upgrade to latest version of play-frontend-hmrc
Remove play-language as transitively pulled in from the latest frontend update (therefore not required)
