### PR TITLE
Dl 12477

### DIFF
--- a/app/uk/gov/hmrc/icedsubscriptionfrontend/services/AuthService.scala
+++ b/app/uk/gov/hmrc/icedsubscriptionfrontend/services/AuthService.scala
@@ -47,7 +47,7 @@ class AuthService @Inject()(val authConnector: AuthConnector)(implicit ec: Execu
   // relying on any correspondence between predicate order and
   // the exception that is thrown in a particular scenario...
   def authenticate()(implicit hc: HeaderCarrier): Future[AuthResult] =
-    authorised(AuthProviders(AuthProvider.GovernmentGateway, AuthProvider.Verify))
+    authorised(AuthProviders(AuthProvider.GovernmentGateway))
       .retrieve(allEnrolments and credentialRole and affinityGroup and credentials) { retrievals =>
         import UserType._
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,4 @@
 import scoverage.ScoverageKeys
-import uk.gov.hmrc.DefaultBuildSettings
 
 val appName = "iced-subscription-frontend"
 
@@ -32,13 +31,4 @@ lazy val microservice = Project(appName, file("."))
     scalacOptions ++= Seq("-Wconf:src=routes/.*:s", "-Wconf:cat=unused-imports&src=html/.*:s")
     // ***************
   )
-//  .configs(IntegrationTest)
   .settings(resolvers += Resolver.jcenterRepo)
-
-lazy val it = project
-  .enablePlugins(PlayScala)
-  .dependsOn(microservice % "test->test") // the "test->test" allows reusing test code and test dependencies
-  .settings(DefaultBuildSettings.itSettings())
-  .settings(libraryDependencies ++= AppDependencies.itDependencies)
-
-

--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,10 @@
 import scoverage.ScoverageKeys
+import uk.gov.hmrc.DefaultBuildSettings
 
 val appName = "iced-subscription-frontend"
 
 ThisBuild / majorVersion := 0
-ThisBuild / scalaVersion := "2.13.8"
+ThisBuild / scalaVersion := "2.13.12"
 
 lazy val microservice = Project(appName, file("."))
   .enablePlugins(
@@ -31,12 +32,13 @@ lazy val microservice = Project(appName, file("."))
     scalacOptions ++= Seq("-Wconf:src=routes/.*:s", "-Wconf:cat=unused-imports&src=html/.*:s")
     // ***************
   )
-  .configs(IntegrationTest)
+//  .configs(IntegrationTest)
   .settings(resolvers += Resolver.jcenterRepo)
 
 lazy val it = project
   .enablePlugins(PlayScala)
   .dependsOn(microservice % "test->test") // the "test->test" allows reusing test code and test dependencies
+  .settings(DefaultBuildSettings.itSettings())
   .settings(libraryDependencies ++= AppDependencies.itDependencies)
 
 

--- a/conf/prod.routes
+++ b/conf/prod.routes
@@ -1,5 +1,3 @@
 # Add all the application routes to the app.routes file
 ->         /safety-and-security-subscription        app.Routes
 ->         /                                        health.Routes
-
-GET        /admin/metrics                           com.kenshoo.play.metrics.MetricsController.metrics

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -1,5 +1,4 @@
-import play.core.PlayVersion
-import sbt._
+import sbt.*
 
 object AppDependencies {
 
@@ -14,8 +13,6 @@ object AppDependencies {
     "uk.gov.hmrc"       %% "bootstrap-test-play-30" % bootstrapVersion,
     "org.scalamock"     %% "scalamock"              % "5.2.0",
     "org.jsoup"         %  "jsoup"                  % "1.16.1"
-//    "com.typesafe.play" %% "play-test"              % PlayVersion.current
   ).map(_ % Test)
 
-  val itDependencies: Seq[ModuleID] = Seq()
 }

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -3,17 +3,19 @@ import sbt._
 
 object AppDependencies {
 
+  val bootstrapVersion = "8.4.0"
+
   val compile: Seq[ModuleID] = Seq(
-    "uk.gov.hmrc" %% "bootstrap-frontend-play-28" % "7.22.0",
-    "uk.gov.hmrc" %% "play-frontend-hmrc-play-28" % "8.4.0",
+    "uk.gov.hmrc" %% "bootstrap-frontend-play-30" % bootstrapVersion,
+    "uk.gov.hmrc" %% "play-frontend-hmrc-play-30" % "8.5.0",
   )
 
   val test: Seq[ModuleID] = Seq(
-    "uk.gov.hmrc"       %% "bootstrap-test-play-28" % "7.22.0",
+    "uk.gov.hmrc"       %% "bootstrap-test-play-30" % bootstrapVersion,
     "org.scalamock"     %% "scalamock"              % "5.2.0",
-    "org.jsoup"         %  "jsoup"                  % "1.16.1",
-    "com.typesafe.play" %% "play-test"              % PlayVersion.current
-  ).map(_ % "test, it")
+    "org.jsoup"         %  "jsoup"                  % "1.16.1"
+//    "com.typesafe.play" %% "play-test"              % PlayVersion.current
+  ).map(_ % Test)
 
   val itDependencies: Seq[ModuleID] = Seq()
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.7.2
+sbt.version=1.9.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,13 +3,13 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.20.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.2.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.5.0")
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.20")
+addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.1")
 
-addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
+addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0" exclude("org.scala-lang.modules", "scala-xml_2.12"))
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.9.3")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.10")
 
 addSbtPlugin("io.github.irundaia" % "sbt-sassify" % "1.5.2")
 

--- a/test/base/SpecBase.scala
+++ b/test/base/SpecBase.scala
@@ -16,7 +16,7 @@
 
 package base
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.TryValues

--- a/test/uk/gov/hmrc/icedsubscriptionfrontend/services/AuthServiceSpec.scala
+++ b/test/uk/gov/hmrc/icedsubscriptionfrontend/services/AuthServiceSpec.scala
@@ -36,7 +36,7 @@ class AuthServiceSpec extends SpecBase with MockAuthConnector {
     def stubAuth()
       : CallHandler[Future[Enrolments ~ Option[CredentialRole] ~ Option[AffinityGroup] ~ Option[Credentials]]] =
       MockAuthConnector.authorise(
-        AuthProviders(AuthProvider.GovernmentGateway, AuthProvider.Verify),
+        AuthProviders(AuthProvider.GovernmentGateway),
         allEnrolments and credentialRole and affinityGroup and credentials)
 
     def activeEnrolment(key: String): Enrolment = Enrolment(key = key)


### PR DESCRIPTION
Play 3.0 upgrade
resolve test compilation issues
remove it test setup as there are no it tests to exdecute

Note - build jobs requires entry to be added so that only tests are ran by default as part of pr builder
https://github.com/hmrc/build-jobs/pull/16441

Note 2 - has upgrade to play frontend hmrc to include new crown so not t be deployed until on or after 19th Feb